### PR TITLE
abort signal support to LLM functions

### DIFF
--- a/app/lib/.server/llm/create-summary.ts
+++ b/app/lib/.server/llm/create-summary.ts
@@ -16,8 +16,10 @@ export async function createSummary(props: {
   promptId?: string;
   contextOptimization?: boolean;
   onFinish?: (resp: GenerateTextResult<Record<string, CoreTool<any, any>>, never>) => void;
+  abortSignal?: AbortSignal;
+
 }) {
-  const { messages, env: serverEnv, apiKeys, providerSettings, onFinish } = props;
+  const { messages, env: serverEnv, apiKeys, providerSettings, onFinish, abortSignal } = props;
   let currentModel = DEFAULT_MODEL;
   let currentProvider = DEFAULT_PROVIDER.name;
   const processedMessages = messages.map((message) => {
@@ -76,8 +78,9 @@ export async function createSummary(props: {
 
   if (summary && summary.type === 'chatSummary') {
     chatId = summary.chatId;
-    summaryText = `The chat summary contains the previous history of the conversation and should be used as context to respond to the user in a coherent manner.        
-${summary.summary}`;
+    summaryText = `Below is the Chat Summary till now, this is chat summary before the conversation provided by the user
+    you should also use this as historical message while providing the response to the user.
+    ${summary.summary}`;
 
     if (chatId) {
       let index = 0;
@@ -181,7 +184,7 @@ Note:
 
 Here is the previous summary of the chat:
 <old_summary>
-${summaryText} 
+${summaryText}
 </old_summary>
 
 Below is the chat after that:
@@ -203,7 +206,9 @@ Please provide a summary of the chat till now including the hitorical summary of
       apiKeys,
       providerSettings,
     }),
+    abortSignal,
   });
+  
 
   const response = resp.text;
 

--- a/app/lib/.server/llm/select-context.ts
+++ b/app/lib/.server/llm/select-context.ts
@@ -22,8 +22,10 @@ export async function selectContext(props: {
   contextOptimization?: boolean;
   summary: string;
   onFinish?: (resp: GenerateTextResult<Record<string, CoreTool<any, any>>, never>) => void;
+  abortSignal?: AbortSignal;
+
 }) {
-  const { messages, env: serverEnv, apiKeys, files, providerSettings, summary, onFinish } = props;
+  const { messages, env: serverEnv, apiKeys, files, providerSettings, summary, onFinish, abortSignal } = props;
   let currentModel = DEFAULT_MODEL;
   let currentProvider = DEFAULT_PROVIDER.name;
   const processedMessages = messages.map((message) => {
@@ -380,7 +382,9 @@ export async function selectContext(props: {
       apiKeys,
       providerSettings,
     }),
+    abortSignal,
   });
+  
 
   const response = resp.text;
   const updateContextBuffer = response.match(/<updateContextBuffer>([\s\S]*?)<\/updateContextBuffer>/);

--- a/app/lib/.server/llm/stream-text.ts
+++ b/app/lib/.server/llm/stream-text.ts
@@ -43,6 +43,8 @@ export async function streamText(props: {
   contextFiles?: FileMap;
   summary?: string;
   messageSliceId?: number;
+  abortSignal?: AbortSignal;
+
 }) {
   const {
     messages,
@@ -55,6 +57,8 @@ export async function streamText(props: {
     contextOptimization,
     contextFiles,
     summary,
+    abortSignal,
+
     isPromptCachingEnabled,
   } = props;
   let currentModel = DEFAULT_MODEL;
@@ -202,6 +206,8 @@ ${props.summary}
         apiKeys,
         providerSettings,
       }),
+      abortSignal,
+
       maxTokens: dynamicMaxTokens,
       messages,
       ...options,

--- a/app/routes/api.llmcall.ts
+++ b/app/routes/api.llmcall.ts
@@ -127,6 +127,8 @@ async function llmCallAction({ context, request }: ActionFunctionArgs) {
         }),
         maxTokens: dynamicMaxTokens,
         toolChoice: 'none',
+        abortSignal: request.signal,
+
       });
         logger.info(`Réponse générée`);
 


### PR DESCRIPTION
This PR fixes chat aborting by passing request.signal to streamText() and generateText()'s abortSignal. (see also: https://sdk.vercel.ai/docs/advanced/stopping-streams).